### PR TITLE
upgrade godot 4.0 beta 16 -> beta 17

### DIFF
--- a/client/build.sh
+++ b/client/build.sh
@@ -3,7 +3,7 @@
 readonly BASE_DIR=$(dirname $(readlink -f "$0"))
 readonly BUILD_DIR="${BASE_DIR}/exports"
 
-# NB: change this to where godot_v4.0-beta16 binary is installed
+# NB: change this to where godot_v4.0-beta17 binary is installed
 readonly GODOT="/path/to/godot/binary"
 readonly TARGET="Web"
 

--- a/client/export_presets.cfg
+++ b/client/export_presets.cfg
@@ -3,6 +3,7 @@
 name="Web"
 platform="Web"
 runnable=true
+dedicated_server=false
 custom_features=""
 export_filter="all_resources"
 include_filter=""
@@ -12,7 +13,6 @@ encryption_include_filters=""
 encryption_exclude_filters=""
 encrypt_pck=false
 encrypt_directory=false
-script_export_mode=1
 script_encryption_key=""
 
 [preset.0.options]

--- a/client/project.godot
+++ b/client/project.godot
@@ -22,5 +22,6 @@ NetworkHandler="*res://src/singletons/network_handler.gd"
 [rendering]
 
 renderer/rendering_method="gl_compatibility"
+textures/vram_compression/import_etc2_astc=true
 environment/defaults/default_clear_color=Color(0, 0, 0, 1)
 textures/canvas_textures/default_texture_filter=0


### PR DESCRIPTION
closes #19

 - enable ASTC in project setting (for web export)